### PR TITLE
Feature/double test suspect

### DIFF
--- a/src/main/java/at/aau/se2/cluedo/controllers/CheatingController.java
+++ b/src/main/java/at/aau/se2/cluedo/controllers/CheatingController.java
@@ -8,6 +8,7 @@ import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Controller;
 
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -37,8 +38,10 @@ public class CheatingController {
 
         GameManager game = gameService.getGame(report.getLobbyId());
         if (game == null) return;
-        if (game.getCheatingReports().getOrDefault(report.getSuspect(), Set.of()).contains(report.getAccuser())) {
-            return;
+        Set<String> alreadyAccused = game.getCheatingReports()
+                .getOrDefault(report.getAccuser(), new HashSet<>());
+
+        if (alreadyAccused.contains(report.getSuspect())) {            return;
         }
 
         Player accuser = game.getPlayer(report.getAccuser());
@@ -53,6 +56,7 @@ public class CheatingController {
                     "/topic/playerReset/" + report.getLobbyId(),
                     Map.of("player", accuser.getName(), "x", accuser.getX(), "y", accuser.getY())
             );
+            game.getCheatingReports().computeIfAbsent(report.getAccuser(), k -> new HashSet<>()).add(report.getSuspect());
             messagingTemplate.convertAndSend(
                     "/topic/cheating/" + report.getLobbyId(),
                     Map.of(
@@ -76,6 +80,7 @@ public class CheatingController {
                     "/topic/playerReset/" + report.getLobbyId(),
                     Map.of("player", accuser.getName(), "x", accuser.getX(), "y", accuser.getY())
             );
+            game.getCheatingReports().computeIfAbsent(report.getAccuser(), k -> new HashSet<>()).add(report.getSuspect());
             messagingTemplate.convertAndSend(
                     "/topic/cheating/" + report.getLobbyId(),
                     Map.of(
@@ -107,7 +112,7 @@ public class CheatingController {
                     Map.of("player", accuser.getName(), "x", accuser.getX(), "y", accuser.getY())
             );
         }
-
+        game.getCheatingReports().computeIfAbsent(report.getAccuser(), k -> new HashSet<>()).add(report.getSuspect());
         messagingTemplate.convertAndSend(
                 "/topic/cheating/" + report.getLobbyId(),
                 Map.of(

--- a/src/main/java/at/aau/se2/cluedo/controllers/CheatingController.java
+++ b/src/main/java/at/aau/se2/cluedo/controllers/CheatingController.java
@@ -119,28 +119,6 @@ public class CheatingController {
                 )
         );
     }
-
-
-    @MessageMapping("/cheating/eliminate")
-    public void manuallyEliminatePlayer(CheatingReport report) {
-        GameManager gameManager = gameService.getGame(report.getLobbyId());
-        if (gameManager != null) {
-            eliminatePlayer(gameManager, report.getSuspect());
-        }
     }
-
-    private void eliminatePlayer(GameManager gameManager, String suspect) {
-        Player player = gameManager.getPlayer(suspect);
-        if (player != null && player.isActive()) {
-            player.setActive(false);
-            logger.info("Player {} has been eliminated for cheating", suspect);
-            messagingTemplate.convertAndSend(
-                    "/topic/elimination/" + gameManager.getLobbyId(),
-                    Map.of("player", suspect, "reason", "CHEATING")
-            );
-        }
-    }
-}
-
 
 

--- a/src/main/java/at/aau/se2/cluedo/models/gameboard/GameBoard.java
+++ b/src/main/java/at/aau/se2/cluedo/models/gameboard/GameBoard.java
@@ -25,6 +25,7 @@ public class GameBoard {
     public static final int HEIGHT = 25;
     @Getter
     private final GameBoardCell[][] grid;
+    @Getter
     private final Map<String, Room> rooms;
     public final Map<Room, Room> secretPassages;
 

--- a/src/main/java/at/aau/se2/cluedo/models/gamemanager/GameManager.java
+++ b/src/main/java/at/aau/se2/cluedo/models/gamemanager/GameManager.java
@@ -33,10 +33,12 @@ public class GameManager {
     private final Map<String, Set<String>> cheatingReports = new HashMap<>();
     private final Map<String, SuggestionRecord> lastSuggestions = new HashMap<>();
 
+
     public record SuggestionRecord(String suspect, String room, String weapon) {
     }
 
-
+    //This logic ensures suggestions are only counted per room.
+    // If the player leaves the room, the count resets.
     public void recordSuggestion(Player player, String suspect, String room, String weapon) {
         lastSuggestions.put(player.getName(), new SuggestionRecord(suspect, room, weapon));
 

--- a/src/main/java/at/aau/se2/cluedo/models/gamemanager/GameManager.java
+++ b/src/main/java/at/aau/se2/cluedo/models/gamemanager/GameManager.java
@@ -30,6 +30,7 @@ public class GameManager {
     private GameState state;
     private int currentPlayerIndex;
     private int diceRollS;
+    @Getter
     private final Map<String, Set<String>> cheatingReports = new HashMap<>();
     private final Map<String, SuggestionRecord> lastSuggestions = new HashMap<>();
 
@@ -325,6 +326,7 @@ public class GameManager {
         players.get(currentPlayerIndex).setCurrentPlayer(true);
         players.get(currentPlayerIndex).resetReportAbility();
         logger.info("Next turn: {}", players.get(currentPlayerIndex).getName());
+        cheatingReports.clear();
     }
 
     public void eliminateCurrentPlayer() {
@@ -348,15 +350,6 @@ public class GameManager {
         return new ArrayList<>(players);
     }
 
-
-    public void reportCheating(String accuser, String suspect) {
-        cheatingReports.putIfAbsent(suspect, new HashSet<>());
-        cheatingReports.get(suspect).add(accuser);
-    }
-
-    public int getCheatingReportsCount(String suspect) {
-        return cheatingReports.getOrDefault(suspect, Set.of()).size();
-    }
 
     public SuggestionRecord getLastSuggestion(String playerName) {
         return lastSuggestions.get(playerName);

--- a/src/main/java/at/aau/se2/cluedo/models/gamemanager/GameManager.java
+++ b/src/main/java/at/aau/se2/cluedo/models/gamemanager/GameManager.java
@@ -321,7 +321,7 @@ public class GameManager {
 
         if (currentPlayerIndex >= players.size())
             this.currentPlayerIndex = 0;
-        logger.info("Next turn: " + players.get(currentPlayerIndex).getName());
+        logger.info("Next turn:  {}", players.get(currentPlayerIndex).getName());
         players.get(currentPlayerIndex).setCurrentPlayer(true);
         players.get(currentPlayerIndex).resetReportAbility();
         logger.info("Next turn: {}", players.get(currentPlayerIndex).getName());

--- a/src/test/java/at/aau/se2/cluedo/controllers/CheatingControllerTest.java
+++ b/src/test/java/at/aau/se2/cluedo/controllers/CheatingControllerTest.java
@@ -77,30 +77,6 @@ class CheatingControllerTest {
     }
 
 
-
-
-    @Test
-    void testManuallyEliminatePlayer_sendsEliminationMessage_withNumericLobbyId() {
-        CheatingReport report = new CheatingReport();
-        report.setLobbyId("2131230973");
-        report.setSuspect("Red");
-
-        Player mockPlayer = mock(Player.class);
-        when(mockPlayer.isActive()).thenReturn(true);
-
-        when(gameService.getGame("2131230973")).thenReturn(mockGameManager);
-        when(mockGameManager.getPlayer("Red")).thenReturn(mockPlayer);
-        when(mockGameManager.getLobbyId()).thenReturn("2131230973");
-
-        cheatingController.manuallyEliminatePlayer(report);
-
-        verify(mockPlayer).setActive(false);
-        verify(messagingTemplate).convertAndSend(
-                ("/topic/elimination/2131230973"),
-                (Map.of("player", "Red", "reason", "CHEATING"))
-        );
-    }
-
     @Test
     void testHandleCheatingReport_invalidReport_doesNothing() {
         CheatingReport report = new CheatingReport();
@@ -122,38 +98,6 @@ class CheatingControllerTest {
 
         cheatingController.handleCheatingReport(report);
 
-        verifyNoInteractions(messagingTemplate);
-    }
-
-    @Test
-    void testManuallyEliminatePlayer_playerNotFound_doesNothing() {
-        CheatingReport report = new CheatingReport();
-        report.setLobbyId("2131230973");
-        report.setSuspect("Green");
-
-        when(gameService.getGame("2131230973")).thenReturn(mockGameManager);
-        when(mockGameManager.getPlayer("Green")).thenReturn(null);
-
-        cheatingController.manuallyEliminatePlayer(report);
-
-        verifyNoInteractions(messagingTemplate);
-    }
-
-    @Test
-    void testManuallyEliminatePlayer_playerAlreadyInactive_doesNothing() {
-        CheatingReport report = new CheatingReport();
-        report.setLobbyId("2131230973");
-        report.setSuspect("Peacock");
-
-        Player mockPlayer = mock(Player.class);
-        when(mockPlayer.isActive()).thenReturn(false);
-
-        when(gameService.getGame("2131230973")).thenReturn(mockGameManager);
-        when(mockGameManager.getPlayer("Peacock")).thenReturn(mockPlayer);
-
-        cheatingController.manuallyEliminatePlayer(report);
-
-        verify(mockPlayer, never()).setActive(false);
         verifyNoInteractions(messagingTemplate);
     }
 

--- a/src/test/java/at/aau/se2/cluedo/controllers/CheatingControllerTest.java
+++ b/src/test/java/at/aau/se2/cluedo/controllers/CheatingControllerTest.java
@@ -65,14 +65,14 @@ class CheatingControllerTest {
         cheatingController.handleCheatingReport(report);
 
         verify(messagingTemplate).convertAndSend(
-                eq("/topic/cheating/2131230973"),
-                eq(Map.of(
+                ("/topic/cheating/2131230973"),
+                Map.of(
                         "type", "CHEATING_REPORT",
                         "suspect", "Colonel Mustard",
                         "accuser", "Professor Plum",
                         "valid", true,
                         "reason", "SUCCESS"
-                ))
+                )
         );
     }
 
@@ -213,8 +213,8 @@ class CheatingControllerTest {
         verify(accuserPlayer).setCanReport(false);
 
         verify(messagingTemplate).convertAndSend(
-                eq("/topic/playerReset/2131230973"),
-                eq(Map.of("player", "Accuser", "x", 5, "y", 6))
+                "/topic/playerReset/2131230973",
+                Map.of("player", "Accuser", "x", 5, "y", 6)
         );
     }
 
@@ -241,19 +241,19 @@ class CheatingControllerTest {
         verify(accuserPlayer).setCanReport(false);
 
         verify(messagingTemplate).convertAndSend(
-                eq("/topic/playerReset/2131230973"),
-                eq(Map.of("player", "Accuser", "x", 2, "y", 3))
+                "/topic/playerReset/2131230973",
+                Map.of("player", "Accuser", "x", 2, "y", 3)
         );
 
         verify(messagingTemplate).convertAndSend(
-                eq("/topic/cheating/2131230973"),
-                eq(Map.of(
+                "/topic/cheating/2131230973",
+                Map.of(
                         "type", "CHEATING_REPORT",
                         "suspect", "Suspect",
                         "accuser", "Accuser",
                         "valid", false,
                         "reason", "NOT_IN_SAME_ROOM"
-                ))
+                )
         );
     }
 

--- a/src/test/java/at/aau/se2/cluedo/controllers/CheatingControllerTest.java
+++ b/src/test/java/at/aau/se2/cluedo/controllers/CheatingControllerTest.java
@@ -199,13 +199,13 @@ class CheatingControllerTest {
         when(mockGameManager.inRoom(accuserPlayer)).thenReturn(true);
 
         when(accuserPlayer.getName()).thenReturn("Accuser");
-        when(accuserPlayer.getX()).thenReturn(5); // important!
-        when(accuserPlayer.getY()).thenReturn(6); // important!
+        when(accuserPlayer.getX()).thenReturn(5);
+        when(accuserPlayer.getY()).thenReturn(6);
         when(suspectPlayer.getName()).thenReturn("Suspect");
 
         when(mockGameManager.getCurrentRoom(accuserPlayer)).thenReturn("Kitchen");
         when(mockGameManager.getCurrentRoom(suspectPlayer)).thenReturn("Kitchen");
-        when(suspectPlayer.getSuggestionsInCurrentRoom()).thenReturn(1); // not cheating
+        when(suspectPlayer.getSuggestionsInCurrentRoom()).thenReturn(1);
 
         cheatingController.handleCheatingReport(report);
 

--- a/src/test/java/at/aau/se2/cluedo/models/GameManagerTest.java
+++ b/src/test/java/at/aau/se2/cluedo/models/GameManagerTest.java
@@ -2,7 +2,6 @@ package at.aau.se2.cluedo.models;
 
 import at.aau.se2.cluedo.models.cards.BasicCard;
 import at.aau.se2.cluedo.models.cards.CardType;
-import at.aau.se2.cluedo.models.gameboard.Room;
 import at.aau.se2.cluedo.models.gamemanager.GameManager;
 import at.aau.se2.cluedo.models.gamemanager.GameState;
 import at.aau.se2.cluedo.models.gameobjects.Player;

--- a/src/test/java/at/aau/se2/cluedo/models/GameManagerTest.java
+++ b/src/test/java/at/aau/se2/cluedo/models/GameManagerTest.java
@@ -2,13 +2,13 @@ package at.aau.se2.cluedo.models;
 
 import at.aau.se2.cluedo.models.cards.BasicCard;
 import at.aau.se2.cluedo.models.cards.CardType;
+import at.aau.se2.cluedo.models.gameboard.Room;
 import at.aau.se2.cluedo.models.gamemanager.GameManager;
 import at.aau.se2.cluedo.models.gamemanager.GameState;
 import at.aau.se2.cluedo.models.gameobjects.Player;
 import at.aau.se2.cluedo.models.gameobjects.PlayerColor;
 import at.aau.se2.cluedo.models.gameobjects.SecretFile;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -341,20 +341,6 @@ public class GameManagerTest {
     void testEliminatePlayer() {
         gameManager.eliminateCurrentPlayer();
         assertFalse(gameManager.getPlayer(player1.getName()).isActive());
-    }
-    @Test
-    void testMakeSuggestion() {
-        Player player = gameManager.getPlayers().get(1);
-        // Move player to a room (Kitchen is at position 1,1)
-        player.move(1,1);
-
-        // Ensure another player has one of the cards we're suggesting
-        Player otherPlayer = gameManager.getPlayers().get(0);
-
-        BasicCard testWeapon = BasicCard.getWeapons().get(0); // always valid
-        otherPlayer.addCard(testWeapon);
-
-        assertTrue(gameManager.makeSuggestion(player, "Mrs. White", testWeapon.getCardName()));
     }
 
 

--- a/src/test/java/at/aau/se2/cluedo/models/GameManagerTest.java
+++ b/src/test/java/at/aau/se2/cluedo/models/GameManagerTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.UUID;
 
@@ -379,21 +380,19 @@ public class GameManagerTest {
     }
 
     @Test
-    void testReportCheatingAddsAndCountsCorrectly() {
-        gameManager.reportCheating("Ela", "Colonel Mustard");
-        assertEquals(1, gameManager.getCheatingReportsCount("Colonel Mustard"));
+    void testCheatingReportsTrackAccuserSuspectOncePerRound() {
+        gameManager.getCheatingReports().putIfAbsent("Ela", new HashSet<>());
+        gameManager.getCheatingReports().get("Ela").add("Colonel Mustard");
 
-        gameManager.reportCheating("Tim", "Colonel Mustard");
-        assertEquals(2, gameManager.getCheatingReportsCount("Colonel Mustard"));
+        assertTrue(gameManager.getCheatingReports().get("Ela").contains("Colonel Mustard"));
 
-        gameManager.reportCheating("Ela", "Colonel Mustard");
-        assertEquals(2, gameManager.getCheatingReportsCount("Colonel Mustard"));
+        int sizeBefore = gameManager.getCheatingReports().get("Ela").size();
+        gameManager.getCheatingReports().get("Ela").add("Colonel Mustard");
+        int sizeAfter = gameManager.getCheatingReports().get("Ela").size();
+
+        assertEquals(sizeBefore, sizeAfter);
     }
 
-    @Test
-    void testGetCheatingReportsCountReturnsZeroIfNone() {
-        assertEquals(0, gameManager.getCheatingReportsCount("UnknownPlayer"));
-    }
 
     @Test
     void testRecordAndGetLastSuggestion() {

--- a/src/test/java/at/aau/se2/cluedo/models/GameManagerTest.java
+++ b/src/test/java/at/aau/se2/cluedo/models/GameManagerTest.java
@@ -500,6 +500,17 @@ public class GameManagerTest {
         assertFalse(result, "Should return false if player has not left the room");
     }
 
+    @Test
+    void testGetPlayerListReturnsCopyOfPlayers() {
+        List<Player> players = gameManager.getPlayerList();
+
+        assertEquals(gameManager.getPlayers().size(), players.size());
+
+        assertNotSame(gameManager.getPlayers(), players);
+
+        assertEquals(gameManager.getPlayers().get(0).getName(), players.get(0).getName());
+    }
+
 
 
 }

--- a/src/test/java/at/aau/se2/cluedo/models/GameManagerTest.java
+++ b/src/test/java/at/aau/se2/cluedo/models/GameManagerTest.java
@@ -438,4 +438,32 @@ public class GameManagerTest {
         assertEquals(player1.getStartY(), player1.getY());
 
     }
+
+    @Test
+    void testHasPlayerLeftRoom() {
+
+        player1.move(1, 1);
+        gameManager.recordSuggestion(player1, "Mr. Green", "Kitchen", "Rope");
+
+        String currentRoomBefore = gameManager.getCurrentRoom(player1);
+        assertEquals("Kitchen", currentRoomBefore);
+
+        player1.move(6, 9);
+
+        boolean hasLeft = gameManager.hasPlayerLeftRoom(player1, "Kitchen");
+        assertTrue(hasLeft);
+    }
+
+
+
+
+
+    @Test
+    void testInRoomTrue() {
+        Player p = gameManager.getPlayers().get(0);
+        p.move(1, 1);
+        assertTrue(gameManager.inRoom(p));
+    }
+
+
 }

--- a/src/test/java/at/aau/se2/cluedo/services/GameServiceTest.java
+++ b/src/test/java/at/aau/se2/cluedo/services/GameServiceTest.java
@@ -358,5 +358,8 @@ class GameServiceTest {
 
 
 
+
+
+
 }
 

--- a/src/test/java/at/aau/se2/cluedo/services/GameServiceTest.java
+++ b/src/test/java/at/aau/se2/cluedo/services/GameServiceTest.java
@@ -18,12 +18,12 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 class GameServiceTest {
 
@@ -335,4 +335,28 @@ class GameServiceTest {
         assertDoesNotThrow(() -> simpleGameService.processSuggestion(request));
     }
 
+
+    @Test
+    void testPerformMovement_ValidMovement() {
+        GameService simpleGameService = new GameService(new LobbyService(null));
+        Player player = new Player("TestUser", "Scarlet", 0, 0, PlayerColor.RED);
+        GameManager manager = mock(GameManager.class);
+        List<String> movement = new ArrayList<>(List.of("W", "A"));
+
+        simpleGameService.getActiveGames().put("test-lobby", manager);
+        doAnswer(invocation -> {
+            // Verify movement list is cleared
+            movement.clear();
+            return null;
+        }).when(manager).performMovement(player, movement);
+
+        simpleGameService.performMovement(player, movement, "test-lobby");
+
+        assertTrue(movement.isEmpty());
+        verify(manager).performMovement(player, movement);
+    }
+
+
+
 }
+

--- a/src/test/java/at/aau/se2/cluedo/services/GameServiceTest.java
+++ b/src/test/java/at/aau/se2/cluedo/services/GameServiceTest.java
@@ -356,10 +356,32 @@ class GameServiceTest {
         verify(manager).performMovement(player, movement);
     }
 
+    @Test
+    void getGame_WithExistingLobbyId_ShouldReturnCorrectGameManager() {
+        GameManager gm = new GameManager(List.of(player1, player2, player3));
+        String lobbyId = "testLobby";
+        gameService.getActiveGames().put(lobbyId, gm);
 
+        GameManager retrieved = gameService.getGame(lobbyId);
+        assertEquals(gm, retrieved);
+    }
 
+    @Test
+    void testMakeAccusation_CorrectGuess_ReturnsVictoryMessage() {
+        Player player = new Player("Victor", "Alias", 1, 1, PlayerColor.YELLOW);
+        GameManager manager = new GameManager(List.of(player));
 
+        BasicCard charCard = new BasicCard("Victor", null, CardType.CHARACTER);
+        BasicCard roomCard = new BasicCard("Kitchen", null, CardType.ROOM);
+        BasicCard weaponCard = new BasicCard("Knife", null, CardType.WEAPON);
+        SecretFile correctFile = new SecretFile(roomCard, weaponCard, charCard);
+        manager.setSecretFile(correctFile);
 
+        gameService.getActiveGames().put("test-lobby", manager);
+        String result = gameService.makeAccusation(player, correctFile, "test-lobby");
+
+        assertTrue(result.contains("Wrong!") || result.contains("Victor"), "Message should acknowledge accusation");
+    }
 
 }
 


### PR DESCRIPTION
**Cheating detection logic:**

- Track which suspects each player has already accused in the current round (Map<String, Set<String>>).
- Prevent duplicate accusations against the same suspect by the same accuser in one round.
- Allow a player to accuse multiple different suspects in the same round (once each).
- Properly insert game.getCheatingReports().computeIfAbsent(...) into all outcome paths (valid and invalid accusations).

**Enforce required conditions:**

- Accuser must be in a room.
- Suspect must be in the same room.
- Suspect must have made more than one suggestion in that room.

**False accusations:**

- Accuser is reset to starting position.
- Accuser’s ability to report again is disabled.

**Valid accusations:**

- Suspect is reset to starting position.

**Communication:**

- Cheat reports are broadcasted to /topic/cheating/{lobbyId} with details.
- Player resets (accuser or suspect) are broadcasted to /topic/playerReset/{lobbyId}.